### PR TITLE
Exit select mode with <C-[> and <C-c>

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -111,6 +111,10 @@ def get_sel(view, num):
     return view.sel()[num]
 
 
+def num_sels(view):
+    return len(view.sel())
+
+
 def first_sel(view):
     return get_sel(view, 0)
 

--- a/tests/test_entering_normal_mode.py
+++ b/tests/test_entering_normal_mode.py
@@ -86,17 +86,3 @@ class Test_vi_enter_normal_mode__MulipleSelections__FromNormalMode(ViewTest):
         self.view.run_command('_enter_normal_mode', {'mode': MODE_NORMAL})
         self.assertEqual(self.R((1, 0), (1, 0)), first_sel(self.view))
         self.assertEqual(1, num_sels(self.view))
-
-
-class Test_vi_enter_normal_mode__MulipleSelections__FromInternalNormalMode(ViewTest):
-    def testCaretEndsInExpectedRegion(self):
-        self.write('foo bar\nfoo bar\nfoo bar\n')
-        self.clear_sel()
-        self.add_sel(self.R((1, 0), (1, 0)))
-        self.add_sel(self.R((2, 0), (2, 0)))
-
-        State(self.view).mode = _MODE_INTERNAL_NORMAL
-
-        self.view.run_command('_enter_normal_mode', {'mode': _MODE_INTERNAL_NORMAL})
-        self.assertEqual(self.R((1, 0), (1, 0)), first_sel(self.view))
-        self.assertEqual(1, num_sels(self.view))

--- a/tests/test_entering_normal_mode.py
+++ b/tests/test_entering_normal_mode.py
@@ -86,3 +86,17 @@ class Test_vi_enter_normal_mode__MulipleSelections__FromNormalMode(ViewTest):
         self.view.run_command('_enter_normal_mode', {'mode': MODE_NORMAL})
         self.assertEqual(self.R((1, 0), (1, 0)), first_sel(self.view))
         self.assertEqual(1, num_sels(self.view))
+
+
+class Test_vi_enter_normal_mode__MulipleSelections__FromInternalNormalMode(ViewTest):
+    def testCaretEndsInExpectedRegion(self):
+        self.write('foo bar\nfoo bar\nfoo bar\n')
+        self.clear_sel()
+        self.add_sel(self.R((1, 0), (1, 0)))
+        self.add_sel(self.R((2, 0), (2, 0)))
+
+        State(self.view).mode = _MODE_INTERNAL_NORMAL
+
+        self.view.run_command('_enter_normal_mode', {'mode': _MODE_INTERNAL_NORMAL})
+        self.assertEqual(self.R((1, 0), (1, 0)), first_sel(self.view))
+        self.assertEqual(1, num_sels(self.view))

--- a/tests/test_entering_normal_mode.py
+++ b/tests/test_entering_normal_mode.py
@@ -2,13 +2,15 @@ import unittest
 
 from NeoVintageous.vi.constants import _MODE_INTERNAL_NORMAL
 from NeoVintageous.vi.constants import MODE_NORMAL
+from NeoVintageous.vi.constants import MODE_SELECT
 from NeoVintageous.vi.constants import MODE_VISUAL
 from NeoVintageous.vi.constants import MODE_VISUAL_LINE
 from NeoVintageous.lib.state import State
 # from NeoVintageous.vi.actions import vi_r
 
-from NeoVintageous.tests import get_sel
+from NeoVintageous.tests import num_sels
 from NeoVintageous.tests import first_sel
+from NeoVintageous.tests import second_sel
 from NeoVintageous.tests import ViewTest
 
 
@@ -55,3 +57,32 @@ class Test_vi_r__SingleSelection__RightToLeft(ViewTest):
         self.view.run_command('vi_run', data)
 
         self.assertEqual(self.R((1, 0), (1, 0)), first_sel(self.view))
+
+
+class Test_vi_enter_normal_mode__MulipleSelections__FromSelectMode(ViewTest):
+    def testCaretsEndInExpectedRegion(self):
+        self.write('foo bar\nfoo bar\nfoo bar\n')
+        self.clear_sel()
+        self.add_sel(self.R((1, 0), (1, 3)))
+        self.add_sel(self.R((2, 0), (2, 3)))
+
+        State(self.view).mode = MODE_SELECT
+
+        self.view.run_command('_enter_normal_mode', {'mode': MODE_SELECT})
+        self.assertEqual(self.R((1, 0), (1, 0)), first_sel(self.view))
+        self.assertEqual(self.R((2, 0), (2, 0)), second_sel(self.view))
+        self.assertEqual(2, num_sels(self.view))
+
+
+class Test_vi_enter_normal_mode__MulipleSelections__FromNormalMode(ViewTest):
+    def testCaretEndsInExpectedRegion(self):
+        self.write('foo bar\nfoo bar\nfoo bar\n')
+        self.clear_sel()
+        self.add_sel(self.R((1, 0), (1, 0)))
+        self.add_sel(self.R((2, 0), (2, 0)))
+
+        State(self.view).mode = MODE_NORMAL
+
+        self.view.run_command('_enter_normal_mode', {'mode': MODE_NORMAL})
+        self.assertEqual(self.R((1, 0), (1, 0)), first_sel(self.view))
+        self.assertEqual(1, num_sels(self.view))

--- a/vi/cmd_defs.py
+++ b/vi/cmd_defs.py
@@ -2164,8 +2164,8 @@ class ViEnterInserMode(ViOperatorDef):
 
 
 @keys.assign(seq=seqs.ESC, modes=_MODES_ACTION)
-@keys.assign(seq=seqs.CTRL_C, modes=_MODES_ACTION)
-@keys.assign(seq=seqs.CTRL_LEFT_SQUARE_BRACKET, modes=_MODES_ACTION)
+@keys.assign(seq=seqs.CTRL_C, modes=_MODES_ACTION + (modes.SELECT,))
+@keys.assign(seq=seqs.CTRL_LEFT_SQUARE_BRACKET, modes=_MODES_ACTION + (modes.SELECT,))
 class ViEnterNormalMode(ViOperatorDef):
     """
     Vim: `<esc>`

--- a/xactions.py
+++ b/xactions.py
@@ -398,8 +398,6 @@ class _enter_normal_mode_impl(ViTextCommandBase):
 
                 return R(s.b)
 
-            if mode == modes.INTERNAL_NORMAL:
-                return R(s.b)
 
             if mode == modes.VISUAL:
                 if s.a < s.b:
@@ -435,7 +433,7 @@ class _enter_normal_mode_impl(ViTextCommandBase):
         if mode == modes.UNKNOWN:
             return
 
-        if (len(self.view.sel()) > 1) and (mode == modes.NORMAL):
+        if (len(self.view.sel()) > 1) and mode in (modes.NORMAL, modes.INTERNAL_NORMAL):
             sel = self.view.sel()[0]
             self.view.sel().clear()
             self.view.sel().add(sel)

--- a/xactions.py
+++ b/xactions.py
@@ -398,6 +398,8 @@ class _enter_normal_mode_impl(ViTextCommandBase):
 
                 return R(s.b)
 
+            if mode == modes.INTERNAL_NORMAL:
+                return R(s.b)
 
             if mode == modes.VISUAL:
                 if s.a < s.b:
@@ -433,7 +435,7 @@ class _enter_normal_mode_impl(ViTextCommandBase):
         if mode == modes.UNKNOWN:
             return
 
-        if (len(self.view.sel()) > 1) and mode in (modes.NORMAL, modes.INTERNAL_NORMAL):
+        if (len(self.view.sel()) > 1) and (mode == modes.NORMAL):
             sel = self.view.sel()[0]
             self.view.sel().clear()
             self.view.sel().add(sel)


### PR DESCRIPTION
This enables `<C-[>` and `<C-c>` to exit select mode back into normal mode.

In enabling this I found a small issue where multiple cursors were not cleared when entering `NORMAL_MODE` from `INTERNAL_NORMAL_MODE` using these new key bindings. Using `<esc>` seems to bypass the normal key processing flow so this behaviour was not previously apparent.
I added a few tests and fixed the issue.