### PR TITLE
Add sidebar and overlay hjkl navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes are documented in this file using the [Keep a CHANGELOG](http://keepachangelog.com/) principles.
 
+## Unreleased
+
+### Added
+
+* Added: sidebar navigation
+
+    Key | Description
+    --- | -----------
+    <kbd>j</kbd> | down
+    <kbd>k</kbd> | up
+    <kbd>h</kbd> | close node / go to parent node
+    <kbd>l</kbd> | open node
+
+* Added: overlay navigation
+
+    Key | Description
+    --- | -----------
+    <kbd>ctrl+j</kbd> | down
+    <kbd>ctrl+k</kbd> | up
+
 ## 1.0.1 - 2017-04-28
 
 ### Fixed

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -444,5 +444,68 @@
     { "keys": ["down"], "command": "cycle_cmdline_history",                               "context": [{"key": "vi_is_cmdline"}] },
 
     { "keys": ["tab"],   "command": "fs_completion", "context": [{"key": "vi_is_cmdline"}, {"key": "vi_cmdline_at_fs_completion"}] },
-    { "keys": ["tab"],   "command": "vi_setting_completion", "context": [{"key": "vi_is_cmdline"}, {"key": "vi_cmdline_at_setting_completion"}] }
+    { "keys": ["tab"],   "command": "vi_setting_completion", "context": [{"key": "vi_is_cmdline"}, {"key": "vi_cmdline_at_setting_completion"}] },
+
+
+    /////////////////////////////////
+    // Tree View - Sidebar control //
+    /////////////////////////////////
+
+    {
+        "keys": ["h"],
+        "command": "move",
+        "args": {"by": "characters", "forward": false},
+        "context": [
+            { "key": "control", "operand": "sidebar_tree" }
+        ]
+    },
+    {
+        "keys": ["j"],
+        "command": "move",
+        "args": {"by": "lines", "forward": true},
+        "context": [
+            { "key": "control", "operand": "sidebar_tree" }
+        ]
+    },
+    {
+        "keys": ["k"],
+        "command": "move",
+        "args": {"by": "lines", "forward": false},
+        "context": [
+            { "key": "control", "operand": "sidebar_tree" }
+        ]
+    },
+    {
+        "keys": ["l"],
+        "command": "move",
+        "args": {"by": "characters", "forward": true},
+        "context": [
+            { "key": "control", "operand": "sidebar_tree" }
+        ]
+    },
+
+    /////////////////////
+    // Overlay control //
+    /////////////////////
+
+    {
+        "keys": ["ctrl+j"],
+        "command": "move",
+        "args": {"by": "lines", "forward": true},
+        "context": [
+            { "key": "overlay_visible" },
+            { "key": "control", "operand": "overlay_control" },
+            { "key": "setting.vintageous_use_ctrl_keys" }
+        ]
+    },
+    {
+        "keys": ["ctrl+k"],
+        "command": "move",
+        "args": {"by": "lines", "forward": false},
+        "context": [
+            { "key": "overlay_visible" },
+            { "key": "control", "operand": "overlay_control" },
+            { "key": "setting.vintageous_use_ctrl_keys" }
+        ]
+    }
 ]


### PR DESCRIPTION
These features are ported over from:  https://github.com/gerardroche/sublime-polyfill. 

Are the `ctrl+j` and `ctrl+k` the correct keymaps to use for OSX?

There are more features from the polyfill package that can probably be ported over to neo, but I left them out for the moment because some of them will need feature toggles and some are a little experimental.