### PR TITLE
Fix shell filtering on OS X, refactor, improve escaping.

### DIFF
--- a/lib/ex/plat/linux.py
+++ b/lib/ex/plat/linux.py
@@ -1,31 +1,14 @@
-import os
-import subprocess
-from subprocess import PIPE
+from NeoVintageous.lib.ex.plat import unixlike
 
 
 def run_and_wait(view, cmd):
-    term = view.settings().get('VintageousEx_linux_terminal')
-    term = term or os.path.expandvars("$COLORTERM") or os.path.expandvars("$TERM")
-    subprocess.Popen([
-        term, '-e',
-        "bash -c \"%s; read -p 'Press RETURN to exit.'\"" % cmd]).wait()
+    unixlike.run_and_wait(view, cmd, 'VintageousEx_linux_terminal')
 
 
 def run_and_read(view, cmd):
-    out, err = subprocess.Popen([cmd],
-                                stdout=PIPE,
-                                stderr=PIPE,
-                                shell=True).communicate()
-    try:
-        return (out or err).decode('utf-8')
-    except AttributeError:
-        return ''
+    return unixlike.run_and_read(view, cmd)
 
 
 def filter_region(view, text, command):
-    shell = view.settings().get('VintageousEx_linux_shell')
-    shell = shell or os.path.expandvars("$SHELL")
-    p = subprocess.Popen([shell, '-c', 'echo "%s" | %s' % (text, command)],
-                         stderr=subprocess.PIPE,
-                         stdout=subprocess.PIPE)
-    return p.communicate()[0][:-1].decode('utf-8')
+    return unixlike.filter_region(
+        view, text, command, 'VintageousEx_linux_shell')

--- a/lib/ex/plat/osx.py
+++ b/lib/ex/plat/osx.py
@@ -1,32 +1,14 @@
-import os
-import subprocess
-from subprocess import PIPE
+from NeoVintageous.lib.ex.plat import unixlike
 
 
 def run_and_wait(view, cmd):
-    term = view.settings().get('VintageousEx_osx_terminal')
-    term = term or os.path.expandvars("$COLORTERM") or os.path.expandvars("$TERM")
-    subprocess.Popen([
-        term, '-e',
-        "bash -c \"%s; read -p 'Press RETURN to exit.'\"" % cmd]).wait()
+    unixlike.run_and_wait(view, cmd, 'VintageousEx_osx_terminal')
 
 
 def run_and_read(view, cmd):
-    out, err = subprocess.Popen([cmd],
-                                stdout=PIPE,
-                                stderr=PIPE,
-                                shell=True).communicate()
-    try:
-        return (out or err).decode('utf-8')
-    except AttributeError:
-        return ''
+    return unixlike.run_and_read(view, cmd)
 
 
 def filter_region(view, text, command):
-    shell = view.settings().get('VintageousEx_osx_shell')
-    shell = shell or os.path.expandvars("$SHELL")
-    p = subprocess.Popen([shell, '-c', 'echo "%s" | %s' % (text, command)],
-                         stdout=subprocess.PIPE,
-                         stderr=subprocess.PIPE)
-    out, err = p.communicate()[0][:-1]
-    return out or err
+    return unixlike.filter_region(
+        view, text, command, 'VintageousEx_osx_shell')

--- a/lib/ex/plat/unixlike.py
+++ b/lib/ex/plat/unixlike.py
@@ -1,0 +1,38 @@
+# Code shared between unix-like platforms (Linux and OS X).
+
+import os
+import subprocess
+
+
+def run_and_wait(view, cmd, terminal_setting_name):
+    term = view.settings().get(terminal_setting_name)
+    term = term or os.path.expandvars("$COLORTERM") or os.path.expandvars("$TERM")
+    subprocess.Popen([
+        term, '-e',
+        "bash -c \"%s; read -p 'Press RETURN to exit.'\"" % cmd]).wait()
+
+
+def run_and_read(view, cmd):
+    out, err = subprocess.Popen([cmd],
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.PIPE,
+                                shell=True).communicate()
+    try:
+        return (out or err).decode('utf-8')
+    except AttributeError:
+        return ''
+
+
+def filter_region(view, text, command, shell_setting_name):
+    shell = view.settings().get(shell_setting_name)
+    shell = shell or os.path.expandvars("$SHELL")
+    # Redirect STDERR to STDOUT to capture both. This seems to be the behavior
+    # of vim as well.
+    p = subprocess.Popen([shell, '-c', command],
+                         stdin=subprocess.PIPE,
+                         stdout=subprocess.PIPE,
+                         stderr=subprocess.STDOUT)
+    # Pass in text as input; this saves us from having to deal with quoting
+    # stuff.
+    out, _ = p.communicate(text.encode('utf-8'))
+    return out.decode('utf-8', errors='backslashreplace')

--- a/tests/lib/ex/test_shell_out.py
+++ b/tests/lib/ex/test_shell_out.py
@@ -32,8 +32,9 @@ class TestExShellOutNoInput(ViewTestCase):
 
 class TestExShellOutFilterThroughShell(ViewTestCase):
 
-    # TODO Implement .!{cmd} (Ex Shell Out) test for Windows and OSX
-    @unittest.skipIf(sublime.platform() == 'windows' or sublime.platform() == "osx", 'Test only works in Linux')
+    # TODO Implement .!{cmd} (Ex Shell Out) test for Windows
+    @unittest.skipIf(sublime.platform() == 'windows',
+                     'Test does not work on Windows')
     def test_simple_filter_through_shell(self):
         self.write("two words\nbbb\nccc")
         self.select(2)
@@ -42,10 +43,42 @@ class TestExShellOutFilterThroughShell(ViewTestCase):
             'command_line': '.! wc -w'
         })
 
-        self.assertContent("2\nbbb\nccc")
+        # Ignore whitespace for the first line as on OS X "wc -l" pads the
+        # number with whitespace like this:
+        # $ echo hi ho | wc -w
+        #        2
+        self.assertContentMatches(r"\s*2\nbbb\nccc")
 
-    # TODO Implement .!{cmd} (Ex Shell Out) test for Windows and OSX
-    @unittest.skipIf(sublime.platform() == 'windows' or sublime.platform() == "osx", 'Test only works in Linux')
+    # TODO Implement .!{cmd} (Ex Shell Out) test for Windows
+    @unittest.skipIf(sublime.platform() == 'windows',
+                     'Test does not work on Windows')
+    def test_command_escaping(self):
+        """Tests that command is escaped correctly."""
+        self.write('this gets replaced')
+        self.select(2)
+
+        self.view.run_command('ex_shell_out', {
+            'command_line': '.! echo \\"one\\" \\\'two\\\''
+        })
+        self.assertContent('"one" \'two\'\n')
+
+    # TODO Implement .!{cmd} (Ex Shell Out) test for Windows
+    @unittest.skipIf(sublime.platform() == 'windows',
+                     'Test does not work on Windows')
+    def test_text_escaping(self):
+        """Tests that text is escaped correctly when passed to command."""
+        line = 'this "contains" \'quotes\' "; false; echo "\n'
+        self.write(line)
+        self.select(2)
+
+        self.view.run_command('ex_shell_out', {
+            'command_line': '.! cat'
+        })
+        self.assertContent(line)
+
+    # TODO Implement .!{cmd} (Ex Shell Out) test for Windows
+    @unittest.skipIf(sublime.platform() == 'windows',
+                     'Test does not work on Windows')
     def test_multiple_filter_through_shell(self):
         self.write("aaa\nthree short words\nccc")
         self.select(10)
@@ -54,4 +87,4 @@ class TestExShellOutFilterThroughShell(ViewTestCase):
             'command_line': '.! wc -w'
         })
 
-        self.assertContent("aaa\n3\nccc")
+        self.assertContentMatches(r"aaa\n\s*3\nccc")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -100,7 +100,12 @@ class ViewTestCase(TestCase):
         self.assertEqual(expected_region, actual_region, msg)
 
     def assertContent(self, expected, msg=None):
-        self.assertEqual(self.view.substr(Region(0, self.view.size())), expected, msg)
+        content = self.content()
+        self.assertEqual(content, expected, msg)
+
+    def assertContentMatches(self, regex, msg=None):
+        content = self.content()
+        self.assertRegex(content, regex, msg)
 
     def assertSize(self, expected):
         self.assertEqual(expected, self.view.size())


### PR DESCRIPTION
Shell filtering was broken on OS X (it was exploding on
`out, err = p.communicate()[0][:-1]` line in osx.py.

This commit:
* fixes the above bug,
* refactors `linux` and `osx` platforms into a common `unixlike` file
  since pretty much all of the code is the same.
* fixes escaping of text by writing to stdin instead of doing an
  unescaped `echo`.
* adds couple tests for checking escaping behavior.
* fixes shell tests on OS X by allowing for extra whitespace emitted
  by `wc -w` on OS X.

Unittests pass on Mac and Linux (apart from 4 tests in lib.test_state that have TODOs that they are failing on CI).