### PR TITLE
Fix Compositions of Partial Mappings

### DIFF
--- a/nv/mappings.py
+++ b/nv/mappings.py
@@ -206,6 +206,10 @@ def mappings_resolve(state, sequence=None, mode=None, check_user_mappings=True):
         # TODO: We should be able to force a mode here too as, below.
         command = _expand_first(state.mode, seq)
 
+        if not command and state.mode == OPERATOR_PENDING:
+            # Check normal mode for mappings.
+            command = _expand_first(NORMAL, seq)
+
     if not command:
         command = seq_to_command(state, seq, mode=mode)
 


### PR DESCRIPTION
Currently, if I have a `.vintageousrc` that looks like:

```
nnoremap L $
nnoremap H 0
```

Then, in normal mode, pressing `L` will map to `$` and take my cursor to the end of the current line, as expected, and similarly for `H`.

Although, when I use `L`, or `H`, in a composite mapping, such as `dL`, `cL`, and so on, then the mapping isn't used.

This PR fixes this issue so that, with the mappings listed above, pressing `dL`, and similar, in normal mode will delete to the end of the line.