### PR TITLE
Add backtick mark

### DIFF
--- a/nv/cmds_vi_actions.py
+++ b/nv/cmds_vi_actions.py
@@ -25,6 +25,7 @@ from sublime import MONOSPACE_FONT
 from sublime import Region
 
 from NeoVintageous.nv.ex_cmds import do_ex_command
+from NeoVintageous.nv.jumplist import jumplist_update
 from NeoVintageous.nv.state import State
 from NeoVintageous.nv.ui import ui_blink
 from NeoVintageous.nv.vi import search
@@ -142,7 +143,6 @@ __all__ = [
     '_vi_p',
     '_vi_q',
     '_vi_quote',
-    '_vi_quote_quote',
     '_vi_r',
     '_vi_s',
     '_vi_select_big_j',
@@ -1084,7 +1084,9 @@ class _vi_quote(ViTextCommandBase):
                 self.view.run_command(address.split(' ')[1][:-1])
             return
 
+        jumplist_update(self.view)
         regions_transformer(self.view, f)
+        jumplist_update(self.view)
 
         if not self.view.visible_region().intersects(address):
             self.view.show_at_center(address)
@@ -1121,16 +1123,9 @@ class _vi_backtick(ViTextCommandBase):
             return
 
         # This is a motion in a composite command.
+        jumplist_update(self.view)
         regions_transformer(self.view, f)
-
-
-class _vi_quote_quote(IrreversibleTextCommand):
-    next_command = 'jump_back'
-
-    def run(self):
-        current = _vi_quote_quote.next_command
-        self.view.window().run_command(current)
-        _vi_quote_quote.next_command = ('jump_forward' if (current == 'jump_back') else 'jump_back')
+        jumplist_update(self.view)
 
 
 class _vi_big_d(ViTextCommandBase):

--- a/nv/jumplist.py
+++ b/nv/jumplist.py
@@ -21,3 +21,7 @@ from Default.history_list import get_jump_history
 def jumplist_update(view):
     # type: (...) -> None
     get_jump_history(view.window().id()).push_selection(view)
+
+
+def jumplist_back(view):
+    return get_jump_history(view.window().id()).jump_back(view)

--- a/nv/vi/cmd_defs.py
+++ b/nv/vi/cmd_defs.py
@@ -2615,22 +2615,15 @@ class ViGotoMark(ViMotionDef):
         return True
 
     def translate(self, state):
-        if self.inp == "'":
-            return {
-                'is_jump': True,
-                'motion': '_vi_quote_quote',
-                'motion_args': {}
+        return {
+            'is_jump': True,
+            'motion': '_vi_quote',
+            'motion_args': {
+                'mode': state.mode,
+                'count': state.count,
+                'character': self.inp
             }
-        else:
-            return {
-                'is_jump': True,
-                'motion': '_vi_quote',
-                'motion_args': {
-                    'mode': state.mode,
-                    'count': state.count,
-                    'character': self.inp
-                }
-            }
+        }
 
 
 @keys.assign(seq=seqs.RIGHT_BRACE, modes=_MODES_MOTION)

--- a/nv/vi/marks.py
+++ b/nv/vi/marks.py
@@ -17,6 +17,8 @@
 
 from sublime import Region
 
+from NeoVintageous.nv.jumplist import jumplist_back
+
 # store: window, view, rowcol
 
 _MARKS = {}
@@ -45,11 +47,18 @@ class Marks(object):
           If `true`, the exact position of the mark is returned. Otherwise,
           the relevant row's 0 column is returned.
         """
-        if name == "'":
-            # Special case: '' motion
-            return '<command _vi_double_single_quote>'
+        win, view, rowcol = None, None, None
+        if name == "'" or name == "`":
+            # Note: We might get a selection outside the current view, which
+            # deviates from vim behaviour.
+            view, selections = jumplist_back(self.state.view)
+            if len(selections) > 0:
+                win = view.window()
+                # TODO: support multiple selections
+                rowcol = view.rowcol(selections[0].b)
+        else:
+            win, view, rowcol = _MARKS.get(name, (None,) * 3)
 
-        win, view, rowcol = _MARKS.get(name, (None,) * 3)
         if win:
             if exact:
                 rowcol_encoded = ':'.join(str(i) for i in rowcol)

--- a/tests/nv/vi/test_marks.py
+++ b/tests/nv/vi/test_marks.py
@@ -81,6 +81,24 @@ class MarksTests(unittest.ViewTestCase):
         expected = "<untitled {0}>:{1}".format(999, "0:0")
         self.assertEqual(self.marks.get_as_encoded_address('a'), expected)
 
-    def test_can_retrieve_single_quote_mark(self):
+    @unittest.mock.patch('NeoVintageous.nv.vi.marks.jumplist_back')
+    def test_can_retrieve_quote_mark(self, mock_jumplist_back):
+        # Single quote mark should call jumplist_back for its region ignoring
+        # any mark set for "'".
+        marks._MARKS['\''] = (Window(), self.view, (0, 0))
+        mock_jumplist_back.return_value = (self.view, [self.Region(30, 30)])
+        self.write(''.join(('foo bar\n') * 10))
+
         location = self.marks.get_as_encoded_address("'")
-        self.assertEqual(location, '<command _vi_double_single_quote>')
+        self.assertEqual(location, self.Region(24, 24))
+
+    @unittest.mock.patch('NeoVintageous.nv.vi.marks.jumplist_back')
+    def test_can_retrieve_backtick_mark(self, mock_jumplist_back):
+        # Backtick mark should call jumplist_back for its region ignoring any
+        # mark set for "`". Here we set exact to true, emulating ``.
+        marks._MARKS['`'] = (Window(), self.view, (0, 0))
+        mock_jumplist_back.return_value = (self.view, [self.Region(30, 30)])
+        self.write(''.join(('foo bar\n') * 10))
+
+        location = self.marks.get_as_encoded_address("`", exact=True)
+        self.assertEqual(location, self.Region(30, 30))


### PR DESCRIPTION
Add jumplist_update calls to jumps caused by marks.

Move '' handling into Marks class and also handle `` (as well as '` and
`'). Now that we update the jumplist on a mark jump there's no need to
track whether the special marks are jumps forward or back. This does
have the side effect of adding jump backs back into the jumplist though.
This won't affect vintageous but will affect sublime jump backs.

Note: This let's you jump back to a different buffer, which isn't something the vi/vim would let you do. But the old implementation also allowed that.

This also fixes a bug with the existing implementation of the ' mark. In that approach next_command should have been reset whenever the jumplist was updated.