### PR TITLE
Adding support for counts against `o` and `O` 

### DIFF
--- a/nv/cmds_vi_actions.py
+++ b/nv/cmds_vi_actions.py
@@ -40,6 +40,7 @@ from NeoVintageous.nv.vi.utils import next_non_blank
 from NeoVintageous.nv.vi.utils import next_non_white_space_char
 from NeoVintageous.nv.vi.utils import previous_non_white_space_char
 from NeoVintageous.nv.vi.utils import regions_transformer
+from NeoVintageous.nv.vi.utils import regions_transformer_indexed
 from NeoVintageous.nv.vi.utils import regions_transformer_reversed
 from NeoVintageous.nv.vi.utils import resolve_insertion_point_at_b
 from NeoVintageous.nv.vim import INSERT
@@ -1481,24 +1482,31 @@ class _vi_equal(ViTextCommandBase):
 class _vi_big_o(ViTextCommandBase):
 
     def run(self, edit, count=1, mode=None):
-        if mode == INTERNAL_NORMAL:
-            self.view.run_command('run_macro_file', {'file': 'res://Packages/Default/Add Line Before.sublime-macro'})
+        def create_selections(view, sel, index):
+            real_sel = Region(sel.a + index * count, sel.b + index * count)
+            start_of_line = view.full_line(real_sel).begin()
+            view.insert(edit, start_of_line, "\n" * count)
+            new = []
+            for i in range(0, count):
+                new.append(Region(start_of_line + i, start_of_line + i))
+            return new
 
+        regions_transformer_indexed(self.view, create_selections)
         self.enter_insert_mode(mode)
 
 
 class _vi_o(ViTextCommandBase):
-
     def run(self, edit, count=1, mode=None):
-        def create_selections(view, sel):
-            end_of_line = view.full_line(sel).max()
+        def create_selections(view, sel, index):
+            real_sel = Region(sel.a + index * count, sel.b + index * count)
+            end_of_line = view.full_line(real_sel).end()
             view.insert(edit, end_of_line, "\n" * count)
             new = []
-            for i in range(1, count):
-                new.append(Region(end_of_line.a + i, end_of_line.b + i))
+            for i in range(0, count):
+                new.append(Region(end_of_line + i, end_of_line + i))
             return new
 
-        regions_transformer(self.view, create_selections)
+        regions_transformer_indexed(self.view, create_selections)
         self.enter_insert_mode(mode)
 
 

--- a/nv/cmds_vi_actions.py
+++ b/nv/cmds_vi_actions.py
@@ -1498,11 +1498,11 @@ class _vi_big_o(ViTextCommandBase):
 class _vi_o(ViTextCommandBase):
     def run(self, edit, count=1, mode=None):
         def create_selections(view, sel, index):
-            real_sel = Region(sel.a + index * count, sel.b + index * count)
-            end_of_line = view.full_line(real_sel).end()
+            real_sel = sel if index == 0 else Region(sel.a + index * count, sel.b + index * count)
+            end_of_line = view.line(real_sel).end()
             view.insert(edit, end_of_line, "\n" * count)
             new = []
-            for i in range(0, count):
+            for i in range(1, count + 1):
                 new.append(Region(end_of_line + i, end_of_line + i))
             return new
 

--- a/nv/cmds_vi_actions.py
+++ b/nv/cmds_vi_actions.py
@@ -1490,9 +1490,15 @@ class _vi_big_o(ViTextCommandBase):
 class _vi_o(ViTextCommandBase):
 
     def run(self, edit, count=1, mode=None):
-        if mode == INTERNAL_NORMAL:
-            self.view.run_command('run_macro_file', {'file': 'res://Packages/Default/Add Line.sublime-macro'})
+        def create_selections(view, sel):
+            end_of_line = view.full_line(sel).max()
+            view.insert(edit, end_of_line, "\n" * count)
+            new = []
+            for i in range(1, count):
+                new.append(Region(end_of_line.a + i, end_of_line.b + i))
+            return new
 
+        regions_transformer(self.view, create_selections)
         self.enter_insert_mode(mode)
 
 

--- a/nv/ex_cmds.py
+++ b/nv/ex_cmds.py
@@ -95,12 +95,18 @@ def _changing_cd(f, *args, **kwargs):
 
             if cmdline_cwd:
                 _log.debug('changing cwd to: %s', cmdline_cwd)
-                os.chdir(cmdline_cwd)
+                if os.path.isdir(cmdline_cwd):
+                    os.chdir(cmdline_cwd)
+                else:
+                    _log.debug('cmdline_cwd is not a valid directory or does not exist')
 
             f(*args, **kwargs)
         finally:
             _log.debug('changing cwd back to: %s', old)
-            os.chdir(old)
+            if os.path.isdir(old):
+                os.chdir(old)
+            else:
+                _log.debug('old cwd is not a valid directory or does not exist')
 
     return inner
 

--- a/nv/ex_cmds.py
+++ b/nv/ex_cmds.py
@@ -84,14 +84,22 @@ def _changing_cd(f, *args, **kwargs):
         state = State(view)
 
         old = os.getcwd()
+        _log.debug('cwd = %s', old)
         try:
             # FIXME: Under some circumstances, like when switching projects to
             # a file whose _cmdline_cd has not been set, _cmdline_cd might
             # return 'None'. In such cases, change to the actual current
             # directory as a last measure. (We should probably fix this anyway).
-            os.chdir(state.settings.vi['_cmdline_cd'] or old)
+            cmdline_cwd = state.settings.vi['_cmdline_cd']
+            _log.debug('cmdline_cwd = %s', cmdline_cwd)
+
+            if cmdline_cwd:
+                _log.debug('changing cwd to: %s', cmdline_cwd)
+                os.chdir(cmdline_cwd)
+
             f(*args, **kwargs)
         finally:
+            _log.debug('changing cwd back to: %s', old)
             os.chdir(old)
 
     return inner

--- a/nv/vi/utils.py
+++ b/nv/vi/utils.py
@@ -68,47 +68,42 @@ def is_view(view):
         is_ignored_but_command_mode(view)
     ))
 
-
-def regions_transformer(view, f):
-    # type: (...) -> None
-    sels = list(view.sel())
+def _regions_transformer(sels, view, f, with_idx):
     new = []
-    for sel in sels:
-        regions = f(view, sel)
+    for idx, sel in enumerate(sels):
+        if with_idx:
+            regions = f(view, sel, idx)
+        else:
+            regions = f(view, sel)
+
         if isinstance(regions, Region):
             new.append(regions)
-        else if isinstance(regions, list):
+        elif isinstance(regions, list):
             for region in regions:
                 if not isinstance(region, Region):
-                    raise TypeError('Region or array of Region required')
+                    raise TypeError('region or array of region required')
                 new.append(region)
         else:
-            raise TypeError('Region or array of Region required')
+            raise TypeError('region or array of region required')
 
     view.sel().clear()
     view.sel().add_all(new)
 
+def regions_transformer(view, f):
+    # type: (...) -> None
+    sels = list(view.sel())
+    _regions_transformer(sels, view, f, False)
 
-# TODO IMPORTANT was refactored from a module that removed vi/constants.py ...
-#       but required by lib/cmds/actions.py module. This can
-#       probably be refactored to use regions_transformer(), in
-#       fact this function probably causes some bugs becayse
-#       regions_transformer() is newer but this function was
-#       looks like it was never updated.
+def regions_transformer_indexed(view, f):
+    # type: (...) -> None
+    sels = list(view.sel())
+    _regions_transformer(sels, view, f, True)
+
+# TODO: test existin uses of this function to make sure the refactor works correctly
 def regions_transformer_reversed(view, f):
     # type: (...) -> None
-
-    # Apply f to every selection region in view and replace existing selections.
-
     sels = reversed(list(view.sel()))
-
-    new_sels = []
-    for s in sels:
-        new_sels.append(f(view, s))
-
-    view.sel().clear()
-    for ns in new_sels:
-        view.sel().add(ns)
+    _regions_transformer(sels, view, f, False)
 
 
 def resolve_insertion_point_at_b(region):

--- a/nv/vi/utils.py
+++ b/nv/vi/utils.py
@@ -99,7 +99,6 @@ def regions_transformer_indexed(view, f):
     sels = list(view.sel())
     _regions_transformer(sels, view, f, True)
 
-# TODO: test existin uses of this function to make sure the refactor works correctly
 def regions_transformer_reversed(view, f):
     # type: (...) -> None
     sels = reversed(list(view.sel()))

--- a/nv/vi/utils.py
+++ b/nv/vi/utils.py
@@ -74,11 +74,16 @@ def regions_transformer(view, f):
     sels = list(view.sel())
     new = []
     for sel in sels:
-        region = f(view, sel)
-        if not isinstance(region, Region):
-            raise TypeError('Region required')
-
-        new.append(region)
+        regions = f(view, sel)
+        if isinstance(regions, Region):
+            new.append(regions)
+        else if isinstance(regions, list):
+            for region in regions:
+                if not isinstance(region, Region):
+                    raise TypeError('Region or array of Region required')
+                new.append(region)
+        else:
+            raise TypeError('Region or array of Region required')
 
     view.sel().clear()
     view.sel().add_all(new)

--- a/tests/functional/test_o.py
+++ b/tests/functional/test_o.py
@@ -36,3 +36,9 @@ class Test_o(unittest.FunctionalTestCase):
     def test_l_o(self):
         self.eq('x\n|fizz\n|x', 'l_o__alt1', 'r_x\n|fizz\n|x')
         self.eq('r_x\n|fizz\n|x', 'l_o__alt1', 'x\n|fizz\n|x')
+
+    def test_multiple_count_o(self):
+        self.eq('|', '2o', 'i_\n|\n|')
+
+    def test_multiple_count_v_o(self):
+        self.eq('fo|o\nba|r', '2o', 'i_foo\n|\n|\nbar\n|\n|')


### PR DESCRIPTION
In VI adding a count before `o` or `O` means that it creates that many
cursors below or above the line you are on and puts you in edit mode
on those cursors.

NB: this is my first PR, and the first python I've written in ~15 years,
so apologies if it's hot garbage :-) It wasn't clear to me the best way
to deal with a situation where multiple inserts are happening re: keeping
selections aligned. I may have re-invented a wheel here accidentally.

I also cleaned up the code in the same location since the refactor to
reuse code *looks* to have worked correctly