### PR TITLE
Pass along environment in ex_setlocal()

### DIFF
--- a/nv/ex_cmds.py
+++ b/nv/ex_cmds.py
@@ -846,7 +846,7 @@ def ex_setlocal(view, option, value, **kwargs):
 def ex_shell(view, **kwargs):
 
     def _open_shell(command):
-        return subprocess.Popen(command, cwd=os.getcwd())
+        return subprocess.Popen(command, cwd=os.getcwd(), env=os.environ)
 
     if platform() == 'linux':
         term = view.settings().get('VintageousEx_linux_terminal')


### PR DESCRIPTION
Found that I couldn't run any of my own shell functions or scripts,
because the subprocess didn't have my environment. I run ST via `subl`
in my terminal, so I expect to have my environment when piping out to a
shell command (ie, `:'<,'>!my_shell_func`). This matches what vim does.