### PR TITLE
Implement #470 Mapping Presets

### DIFF
--- a/nv/rc.py
+++ b/nv/rc.py
@@ -67,6 +67,7 @@ def _unload():
 
 def _load():
     try:
+        _load_preset()
         from NeoVintageous.nv.ex_cmds import do_ex_cmdline
         window = sublime.active_window()
         with builtins.open(_file_path(), 'r') as f:
@@ -78,6 +79,25 @@ def _load():
         print('%s file loaded' % _file_name())
     except FileNotFoundError:
         _log.info('%s file not found', _file_name())
+
+
+def _load_preset():
+    window = sublime.active_window()
+    view = window.active_view()
+    if view:
+        keys = view.settings().get('vintageous_key_presets')
+        if keys and keys in ('idea', 'vwrapper'):
+            file_name = str(keys) + 'rc'
+            resource = sublime.load_resource('Packages/NeoVintageous/res/keypresets/' + file_name)
+            if resource:
+                from NeoVintageous.nv.ex_cmds import do_ex_cmdline
+                window = sublime.active_window()
+                for line in resource.split('\n'):
+                    ex_cmdline = _parse_line(line)
+                    if ex_cmdline:
+                        do_ex_cmdline(window, ex_cmdline)
+
+                print('%s preset file loaded' % file_name)
 
 
 # Recursive mappings (:map, :nmap, :omap, :smap, :vmap) are not supported. They

--- a/res/keypresets/idearc
+++ b/res/keypresets/idearc
@@ -1,0 +1,10 @@
+" This is a preset rc file of IntelliJ IDEAVim style mappings.
+"
+" The character " (the double quote mark) starts a comment
+" Type :h neovintageousrc for help.
+
+" Saving.
+nnoremap <C-s> :w<CR>
+vnoremap <C-s> :w<CR>
+
+nnoremap <C-d> dd

--- a/res/keypresets/vwrapperrc
+++ b/res/keypresets/vwrapperrc
@@ -1,0 +1,6 @@
+" This is a preset rc file of Eclipse vwrapper style mappings.
+"
+" The character " (the double quote mark) starts a comment
+" Type :h neovintageousrc for help.
+
+nnoremap <C-d> dd


### PR DESCRIPTION
This is a proof of concept possibly solution to #470: **support granular vim vs sublime CTRL shortcuts**.

The idea is provide out-of-the-box mapping presets that a user can choose from without need to redefine all the mapping themselves. 

The two examples given here are `idea` and `vwrapper`. To select them set the setting:

```
"vintageous_key_presets": "idea"
```

The preset rc file will be loaded before the user rc file, which means you can still override the preset mappings. 

