### PR TITLE
Allow using `:global` with ex_delete

### DIFF
--- a/nv/ex_cmds.py
+++ b/nv/ex_cmds.py
@@ -280,10 +280,16 @@ def ex_cquit(window, **kwargs):
 
 
 @_serialize_deserialize
-def ex_delete(view, edit, register, line_range, **kwargs):
+def ex_delete(view, edit, register, line_range, global_lines=None, **kwargs):
     r = line_range.resolve(view)
     if r == Region(-1, -1):
         r = view.full_line(0)
+
+    rs = [r]
+
+    # If :global called us, ignore the parsed range.
+    if global_lines:
+        rs = [Region(a, b) for (a, b) in global_lines]
 
     def _select(view, regions, register):
         view.sel().clear()
@@ -301,9 +307,25 @@ def ex_delete(view, edit, register, line_range, **kwargs):
             state = State(view)
             state.registers[register] = [text]
 
-    _select(view, [r], register)
-    view.erase(edit, r)
-    _set_next_sel(view, [(r.a, r.a)])
+    # Save stuff to be deleted in register
+    if global_lines:
+        _select(view, [Region(r.a, r.b - 1) for r in rs], register)
+    else:
+        _select(view, [Region(r.a, r.b) for r in rs], register)
+
+    # Build regions to be selected after deletion
+    deleted_so_far = 0
+    new_sel_pos = []
+    for r in rs:
+        new_sel_pos.append(r.a - deleted_so_far)
+        size_of_region = r.b - r.a
+        deleted_so_far += size_of_region
+
+    # Delete
+    for r in reversed(rs):
+        view.erase(edit, r)
+
+    _set_next_sel(view, [(p, p) for p in new_sel_pos])
 
 
 def ex_double_ampersand(view, edit, flags, count, line_range, **kwargs):

--- a/nv/ex_routes.py
+++ b/nv/ex_routes.py
@@ -112,6 +112,7 @@ def _ex_route_cquit(state):
 
 def _ex_route_delete(state):
     command = TokenCommand('delete')
+    command.cooperates_with_global = True
     command.addressable = True
 
     params = {'register': '"', 'count': None}

--- a/tests/nv/ex/test_scanner.py
+++ b/tests/nv/ex/test_scanner.py
@@ -483,8 +483,8 @@ class Test_scan_command(unittest.TestCase):
         self.assertRoute(['copy .', 'co .'], cmd('copy', params={'address': '.'}, addressable=True))
         self.assertRoute(['copy .+3', 'co .+3'], cmd('copy', params={'address': '.+3'}, addressable=True))
         self.assertRoute(['cquit', 'cq'], cmd('cquit'))
-        self.assertRoute(['delete x', 'd x'], cmd('delete', params={'count': None, 'register': 'x'}, addressable=True))
-        self.assertRoute(['delete', 'd'], cmd('delete', params={'count': None, 'register': '"'}, addressable=True))
+        self.assertRoute(['delete x', 'd x'], cmd('delete', params={'count': None, 'register': 'x'}, addressable=True, cooperates_with_global=True))  # noqa: E501
+        self.assertRoute(['delete', 'd'], cmd('delete', params={'count': None, 'register': '"'}, addressable=True, cooperates_with_global=True))  # noqa: E501
         self.assertRoute(['edit file.txt', 'e file.txt'], cmd('edit', params={'file_name': 'file.txt'}))  # noqa: E501
         self.assertRoute(['edit x/y.txt', 'e x/y.txt'], cmd('edit', params={'file_name': 'x/y.txt'}))  # noqa: E501
         self.assertRoute(['edit!', 'e!'], cmd('edit', params={'file_name': None}, forced=True))  # noqa: E501


### PR DESCRIPTION
This pull request allows deleting lines via the `:g(lobal)` command, e.g.

```
:g/<pattern>/d
```

or

```
:global/<pattern>/delete
```

I have run `UnitTesting` and tests seems to be passing.