### PR TITLE
Fix dates for 2022 releases in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 All notable changes are documented in this file using the [Keep a CHANGELOG](http://keepachangelog.com/) principles.
 
-## 1.26.1 - 2021-02-21
+## 1.26.1 - 2022-02-21
 
 * Fixed [#807](https://github.com/NeoVintageous/NeoVintageous/issues/807): Delete register no longer working on selection made by other plugins
 
-## 1.26.0 - 2021-01-10
+## 1.26.0 - 2022-01-10
 
 ### Added
 


### PR DESCRIPTION
This confused me a little. Feel free to close if you've already addressed it