### PR TITLE
Run user cli commands on mode change

### DIFF
--- a/nv/events_user.py
+++ b/nv/events_user.py
@@ -1,0 +1,70 @@
+import os
+import subprocess
+import logging
+
+from pathlib import Path
+
+import sublime
+
+from NeoVintageous.nv.vim import INSERT, INTERNAL_NORMAL, NORMAL, OPERATOR_PENDING, REPLACE, SELECT, UNKNOWN, VISUAL, VISUAL_BLOCK, VISUAL_LINE
+from NeoVintageous.plugin import cfgU
+
+__all__ = ['NeoVintageousEventsUser'] # User events: run cli commands on mode changes
+
+PLATFORM = sublime.platform()
+_log = logging.getLogger(__name__)
+
+event_modes = {
+    INSERT      	: 'Insert'
+  , NORMAL      	: 'Normal'
+  , REPLACE     	: 'Replace'
+  , SELECT      	: 'Select'
+  , VISUAL      	: 'Visual'
+  , VISUAL_BLOCK	: 'VisualBlock'
+  , VISUAL_LINE 	: 'VisualLine'
+  }
+
+def get_full_cmd(eventsU, event_name) -> list:
+  if type(eventsU) is dict:
+    eventsU_or_OS = None
+    if PLATFORM in eventsU:
+      if type(eventsU_OS := eventsU[PLATFORM]) is dict:
+        eventsU_or_OS = eventsU_OS
+    else:
+      eventsU_or_OS   = eventsU
+    if eventsU_or_OS and event_name in eventsU_or_OS:
+      full_cmd = eventsU_or_OS[event_name]
+      if   type(full_cmd) is list:
+        return  full_cmd
+      elif type(full_cmd) is str: # "path" → ["path"]
+        return [full_cmd]
+
+def on_mode_change  (view   , current_mode, new_mode) -> None:
+  from NeoVintageous.plugin import cfgU
+  _log.debug(f"mode Δ {current_mode} ⟶ {new_mode}")
+  if not hasattr(cfgU, 'events'):
+    return
+  if not (eventsU := cfgU.events):
+    return
+  _log.debug(f"user events = {eventsU}")
+  for mode, mode_cfg_name in event_modes.items():
+    event_name = None
+    if current_mode == mode:
+      event_name = f'{mode_cfg_name}Leave'
+    if new_mode     == mode:
+      event_name = f'{mode_cfg_name}Enter'
+    if event_name:
+      if (full_cmd := get_full_cmd(eventsU, event_name)):
+        run_command(full_cmd, current_mode, new_mode)
+
+def run_command    (full_cmd, current_mode, new_mode) -> None:
+  _log.debug(f"full_cmd = {full_cmd}")
+  if (bin_path := Path(full_cmd[0]).expanduser()).exists():
+    proc  = subprocess.run([bin_path] + full_cmd[1:],capture_output=True)
+    out   = proc.stdout.decode().rstrip('\n')
+    err   = proc.stderr.decode().rstrip('\n')
+    retn  = proc.returncode
+    if err:
+      print(f"NeoVintageous ERROR while Δ mode ‘{current_mode}’ ⟶ ‘{new_mode}’\n and running ‘{full_cmd}’\n{err}")
+  else:
+    print(f"NeoVintageous ERROR while Δ mode ‘{current_mode}’ ⟶ ‘{new_mode},’\n executable does NOT exist: ‘{bin_path}’")

--- a/nv/settings.py
+++ b/nv/settings.py
@@ -26,6 +26,7 @@ from NeoVintageous.nv.session import set_session_value
 from NeoVintageous.nv.session import set_session_view_value
 from NeoVintageous.nv.vim import DIRECTION_DOWN
 from NeoVintageous.nv.vim import UNKNOWN
+from NeoVintageous.nv.events_user import on_mode_change
 
 
 def get_setting(view, name: str, default=None):
@@ -208,6 +209,11 @@ def get_mode(view) -> str:
 
 
 def set_mode(view, value: str) -> None:
+    current_mode = get_mode(view)
+    if not current_mode == value: # mode changes
+       set_session_view_value(view, f'is_{current_mode}', False) # unset old mode
+       set_session_view_value(view, f'is_{value}'       , True ) #   set new mode
+       on_mode_change(view, current_mode, value)
     set_session_view_value(view, 'mode', value)
 
 

--- a/plugin.py
+++ b/plugin.py
@@ -18,6 +18,8 @@
 import os
 import traceback
 
+PACKAGE_NAME  = "NeoVintageous"
+
 # To enable debug logging, set the env var to a non-blank value.
 _DEBUG = bool(os.getenv('SUBLIME_NEOVINTAGEOUS_DEBUG'))
 


### PR DESCRIPTION
By setting something like this in `NeoVintageous.sublime-settings` (a separate file allows using shorter names and subscribing to plugin-specific file changes)
```json5
{
"events"       	: {
  "osx"        	: {
  "InsertEnter"	: ["~/.local/bin/karabiner_cli", "--set-variables", "{\"isNVⓘ\":1}"],
  "InsertLeave"	: ["~/.local/bin/karabiner_cli", "--set-variables", "{\"isNVⓘ\":0}"],
  "NormalEnter"	: ["~/.local/bin/karabiner_cli", "--set-variables", "{\"isNVⓃ\":1}"],
  "NormalLeave"	: ["~/.local/bin/karabiner_cli", "--set-variables", "{\"isNVⓃ\":0}"],
  },
}
}
```

closes #932
