### PR TITLE
Allow user extension of plugin-surround

### DIFF
--- a/nv/rc.py
+++ b/nv/rc.py
@@ -136,6 +136,11 @@ class cfgU():
             _log.warn(f"⚠️‘surround’ in ‘{cfgU_settings}’ should be a dictionary, not {surrT}")
             cfgU.surround = None
 
+        _import_plugins_with_user_data()
+
+def _import_plugins_with_user_data():
+    from NeoVintageous.nv import plugin_surround
+    plugin_surround.reload_with_user_data()
 
 def load_cfgU() -> None: # load alternative user config file to a global class and add a watcher event to track changes
     # load user config file to a global class and add a watcher event to track changes

--- a/plugin.py
+++ b/plugin.py
@@ -18,6 +18,8 @@
 import os
 import traceback
 
+PACKAGE_NAME  = "NeoVintageous"
+
 # To enable debug logging, set the env var to a non-blank value.
 _DEBUG = bool(os.getenv('SUBLIME_NEOVINTAGEOUS_DEBUG'))
 

--- a/plugin.py
+++ b/plugin.py
@@ -61,7 +61,7 @@ import sublime  # noqa: E402
 try:
     _startup_exception = None
 
-    from NeoVintageous.nv.rc import load_rc
+    from NeoVintageous.nv.rc import load_rc, _import_plugins_with_user_data
     from NeoVintageous.nv.session import load_session
     from NeoVintageous.nv.vim import clean_views
 
@@ -171,6 +171,7 @@ def plugin_loaded():
     try:
         load_session()
         load_rc()
+        _import_plugins_with_user_data()
     except Exception as e:  # pragma: no cover
         traceback.print_exc()
         loading_exeption = e

--- a/plugin.py
+++ b/plugin.py
@@ -17,8 +17,10 @@
 
 import os
 import traceback
+import logging
 
 PACKAGE_NAME  = "NeoVintageous"
+DEFAULT_LOG_LEVEL = logging.WARN
 
 # To enable debug logging, set the env var to a non-blank value.
 _DEBUG = bool(os.getenv('SUBLIME_NEOVINTAGEOUS_DEBUG'))
@@ -31,7 +33,6 @@ _DEBUG = bool(os.getenv('SUBLIME_NEOVINTAGEOUS_DEBUG'))
 # WARNING. The end result is that it prints the message to sys.stderr, and in
 # Sublime Text that means it will print the message to console).
 if _DEBUG:  # pragma: no cover
-    import logging
 
     logger = logging.getLogger('NeoVintageous')
 


### PR DESCRIPTION
So you could insert 【more bracket types】 and not use the inconvenient default aliases (why leave home row AND use a modifier ⇧ `'B': '}',` to insert a very common bracket)

(likely conflicts with https://github.com/NeoVintageous/NeoVintageous/pull/933 since this uses an updated config loader moved to rc which reads the existing config, will update the other one after this one is merged)