### PR TITLE
Update Workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,14 +16,14 @@ jobs:
       - name: Setup
         uses: SublimeText/UnitTesting/actions/setup@v1
         with:
-          unittesting-version: ${{ matrix.os == 'ubuntu-latest' && matrix.st-version == 3 && '1.5.9' || '' }}
           sublime-text-version: ${{ matrix.st-version }}
-      - name: Tests
+      - name: Unit Tests
         uses: SublimeText/UnitTesting/actions/run-tests@v1
         with:
-          coverage: ${{ matrix.os == 'ubuntu-latest' && matrix.st-version == 3 }}
-          codecov-upload: ${{ matrix.os == 'ubuntu-latest' && matrix.st-version == 3 }}
+          coverage: true
+      - uses: codecov/codecov-action@v4
       - name: Syntax Tests
+        if: ${{ matrix.os == 'ubuntu-latest' }}
         uses: SublimeText/UnitTesting/actions/run-syntax-tests@v1
       - name: Coding guidelines check
         if: ${{ matrix.os == 'ubuntu-latest' && matrix.st-version == 4 }}


### PR DESCRIPTION
UnitTesting 1.8.0 is released, which fixes issues with reloading packages.

Not sure if or why coverage reports are restricted to single platform and version, hence droped the restrictions.

The major part however is to directly use `codecov/codecov-action@v4` for uploading
as the former `codecov-upload` option of UnitTesting is deprecated.