### PR TITLE
Change vintageous_highlighted_yank_duration to 150, matching Neovim's default timeout duration

### DIFF
--- a/Preferences.sublime-settings
+++ b/Preferences.sublime-settings
@@ -39,7 +39,7 @@
     "vintageous_highlighted_yank": true,
 
     // See https://neovintageous.github.io/reference/settings#vintageous-highlighted-yank-duration
-    "vintageous_highlighted_yank_duration": 1000,
+    "vintageous_highlighted_yank_duration": 150,
 
     // See https://neovintageous.github.io/reference/settings#vintageous-highlighted-yank-style
     "vintageous_highlighted_yank_style": "fill",


### PR DESCRIPTION
The default value for timeout in `vim.hl.on_yank{opts}` is 150 ms. This has been made in order to make the editor feel snappier and to reproduce the behaviour of Neovim with the default configs.

From any neovim editor, using ":h vim.hl.on_yank()" opens the following function from the Nvim reference manual:

```
VIM.HL                                                                *vim.hl*

vim.hl.on_yank({opts})                                      *vim.hl.on_yank()*
    Highlight the yanked text during a |TextYankPost| event.

    Add the following to your `init.vim`:
        autocmd TextYankPost * silent! lua vim.hl.on_yank {higroup='Visual', timeout=300}


    Parameters: ~
      • {opts}  (`table?`) Optional parameters
                • higroup highlight group for yanked region (default
                  "IncSearch")
                • timeout time in ms before highlight is cleared (default 150)
                • on_macro highlight when executing macro (default false)
                • on_visual highlight when yanking visual selection (default
                  true)
                • event event structure (default vim.v.event)
                • priority integer priority (default
                  |vim.hl.priorities|`.user`)
```

As one can see, the default is 150ms. The change was made in the Sublime Text preferences to reflect the same.

(Tested the patch on my own build, and it worked exactly as in Neovim)